### PR TITLE
Copy `.ruby-version` to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apk add --no-cache --update g++ make
 # See: https://github.com/sparklemotion/nokogiri/issues/2430
 RUN apk add --no-cache --update gcompat
 
-COPY Gemfile Gemfile.lock ./
+COPY .ruby-version Gemfile Gemfile.lock ./
 
 RUN bundle install \
     && bundle clean --force \


### PR DESCRIPTION
With the change in a61579c, `.ruby-version` is now a required file in
order to successfully `bundle install`. This is especially true in CI
build jobs.

So, this change copies that file into the container before we run
`bundle install`.
